### PR TITLE
Fix raw_record_line_no in type raw_record

### DIFF
--- a/src/csv.record_parser.m
+++ b/src/csv.record_parser.m
@@ -186,7 +186,7 @@ get_fields(Reader, !.Fields, Result, !LastSeen, !FieldsRead, !ColNo, !State) :-
     ;
         FieldResult = fr_end_of_record,
         list.reverse(!Fields),
-        Result = fsr_fields(raw_record(LineNo, !.Fields))
+        Result = fsr_fields(raw_record(StartLineNo, !.Fields))
     ;
         FieldResult = fr_eof,
         (
@@ -196,7 +196,7 @@ get_fields(Reader, !.Fields, Result, !LastSeen, !FieldsRead, !ColNo, !State) :-
             % The EOF was the terminating this record.
             !.Fields = [_ | _],
             list.reverse(!Fields),
-            Result = fsr_fields(raw_record(LineNo, !.Fields))
+            Result = fsr_fields(raw_record(StartLineNo, !.Fields))
         )
     ).
 

--- a/tests/field_desc_mismatch.err_exp
+++ b/tests/field_desc_mismatch.err_exp
@@ -1,1 +1,1 @@
-field_desc_mismatch.inp:2:1: error: in field #2, expected 2 fields in record: actual: 1
+field_desc_mismatch.inp:1:1: error: in field #2, expected 2 fields in record: actual: 1


### PR DESCRIPTION
Variable StartLineNo contains the right line number of the raw_record.
Variable LineNo is StartLineNo incremented by 1 (in case there is no
newline inside a quoted field).